### PR TITLE
Hotfix/parse error adaptor

### DIFF
--- a/src/services/api/auth.js
+++ b/src/services/api/auth.js
@@ -1,7 +1,9 @@
 import Parse from './parse'
+import { constructErrorFromParseError } from 'services/api/utils/error'
 
 export const SUCCESS = Symbol('SUCCESS')
 export const FAILURE = Symbol('FAILURE')
+
 /*
   authenticate the user using username and password
   async/await is a new pattern adopted in ES2016,
@@ -14,9 +16,7 @@ async function authenticate(username, password){
     const user =  await Parse.User.logIn(username, password)
     return { status: user.authenticated()? SUCCESS:FAILURE, session: user.getSessionToken() }
   } catch (error) {
-    if(error.errors){
-      throw { status: FAILURE, message: error.errors.map( e => e.message ) || error.message }
-    }
+    throw constructErrorFromParseError(error)
   }
 }
 
@@ -25,7 +25,7 @@ async function authenticateUsing(token){
     const user = await Parse.User.become(token)
     return { status: user.authenticated()? SUCCESS:FAILURE, session: user.getSessionToken() }
   } catch (error) {
-    throw { status: FAILURE, message: error.errors.map( e => e.message ) || error.message }
+    throw constructErrorFromParseError(error)
   }
 }
 
@@ -35,11 +35,11 @@ async function deauthenticate(){
       await Parse.User.logOut()
       return { status: SUCCESS }
     } catch (error) {
-      throw { status: FAILURE, message: error.errors.map( e => e.message ) || error.message }
+      throw constructErrorFromParseError(error)
     }
   }
   else {
-    throw { status: FAILURE, message: 'User has not been authenticated' }
+    throw new Error('User has not been authenticated')
   }
 }
 
@@ -55,10 +55,10 @@ async function register(credentials, token){
       await user.signUp()
       return { status: user.authenticated()? SUCCESS:FAILURE, session: user.getSessionToken() }
     } catch (error) {
-      throw { status: FAILURE, message: error.errors.map( e => e.message ) || error.message }
+      throw constructErrorFromParseError(error)
     }
   }
-  throw { status: FAILURE, message: 'Invalid Registration Authorization Token' }
+  throw new Error('Invalid Registration Authorization Token')
 }
 
 export { authenticate, authenticateUsing, deauthenticate, register }

--- a/src/services/api/utils/error.js
+++ b/src/services/api/utils/error.js
@@ -1,0 +1,26 @@
+
+function* yieldNestedErrors(parseError) {
+  if(parseError.errors){
+    // if there are nested errors, yield each one of them
+    for(const err of parseError.errors)
+      yield* yieldNestedErrors(err)
+  }else{
+    // if nothing nested, just yield the argument
+    yield parseError
+  }
+}
+
+/**
+ * Create an Error from the given Parse.Error, handling specially the
+ * AGGREGATE_ERROR that have multiple nested errors.
+ * @arg {Parse.Error} parseError Error to be converted
+ * @returns {Error} Normal Error that has a message
+ */
+export function constructErrorFromParseError(parseError){
+  if(parseError.errors){
+    return new Error(Array.from(yieldNestedErrors(parseError)).map(
+      (e, i) => `[${i + 1}]. ${e.message}`
+    ).join('\n'))
+  }
+  return new Error(parseError.message)
+}

--- a/src/services/api/utils/error.test.js
+++ b/src/services/api/utils/error.test.js
@@ -1,0 +1,51 @@
+import { constructErrorFromParseError } from 'services/api/utils/error'
+
+describe('constructErrorFromParseError', ()=>{
+  it('constructs an error from a normal error', ()=>{
+    const teapotString = 'I am a teapot.'
+    const originalError = new Error(teapotString)
+    const error = constructErrorFromParseError(originalError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBe(originalError)
+    expect(typeof error.message).toBe('string')
+    expect(error.message).toEqual(teapotString)
+  })
+
+  it('constructs an error from an aggregate error', ()=>{
+    const teapotStrings = ['I am a teapot.', 'I am fat.']
+    // hopefully this is similar enough
+    const originalError = new Error()
+    originalError.errors = teapotStrings.map((str)=>new Error(str))
+    const error = constructErrorFromParseError(originalError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBe(originalError)
+    expect(typeof error.message).toBe('string')
+    expect(error.message).toEqual(`[1]. ${teapotStrings[0]}\n[2]. ${teapotStrings[1]}`)
+  })
+
+  it('constructs an error from a nested aggregate error', ()=>{
+    const teapotStrings = ['I am a teapot.', 'I am fat.', 'I am short.']
+    // hopefully this is similar enough
+    const originalError = new Error()
+    const nestedError = new Error()
+    nestedError.errors = [
+      new Error(teapotStrings[1]),
+      new Error(teapotStrings[0]),
+      new Error(teapotStrings[2]),
+    ]
+    originalError.errors = [
+      new Error(teapotStrings[0]),
+      nestedError,
+    ]
+    const error = constructErrorFromParseError(originalError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBe(originalError)
+    expect(typeof error.message).toBe('string')
+    expect(error.message).toEqual([
+      `[1]. ${teapotStrings[0]}`,
+      `[2]. ${teapotStrings[1]}`,
+      `[3]. ${teapotStrings[0]}`,
+      `[4]. ${teapotStrings[2]}`,
+    ].join('\n'))
+  })
+})


### PR DESCRIPTION
```
 PASS  src/services/api/utils/error.test.js
  constructErrorFromParseError
    ✓ constructs an error from a normal error (2ms)
    ✓ constructs an error from an aggregate error (1ms)
    ✓ constructs an error from a nested aggregate error (1ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.088s, estimated 1s
Ran all test suites matching /util/.
```